### PR TITLE
fix requirements.txt

### DIFF
--- a/rede/requirements.txt
+++ b/rede/requirements.txt
@@ -14,5 +14,6 @@ aioflask
 aiohttp
 asgiref
 #para mapa
-folium
+#folium
+branca
 orjson


### PR DESCRIPTION
Ao executar local, obtive a seguinte sáida:

```py
ERROR: Could not find a version that satisfies the requirement branca>=0.6.0 (from folium->-r requirements.txt (line 17)) (from versions: 0.1.1, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 0.4.1, 0.4.2, 0.5.0)
ERROR: No matching distribution found for branca>=0.6.0 (from folium->-r requirements.txt (line 17))
```

Então tentei inserir o `branca` com o `#folium`. Ah sim o comando passou a funcionar:

```py
pip install -r requiriments.txt
```